### PR TITLE
Add local Node.js server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ npm start
 ```
 
 The application will be available at [http://localhost:5000](http://localhost:5000).
+
+Alternatively, you can run the server using Node's built-in `http` module:
+
+```bash
+npm run local
+```
+
+This starts `local.js` which serves the files in the `static` directory.

--- a/local.js
+++ b/local.js
@@ -1,0 +1,28 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 5000;
+
+const server = http.createServer((req, res) => {
+  let filePath = req.url === '/' ? '/index.html' : req.url;
+  const fullPath = path.join(__dirname, 'static', filePath);
+
+  fs.readFile(fullPath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+
+    const ext = path.extname(fullPath);
+    const contentType = ext === '.html' ? 'text/html' : 'text/plain';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Minimal Node.js application serving static HTML",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "local": "node local.js"
   },
   "dependencies": {
     "express": "^4.18.2"


### PR DESCRIPTION
## Summary
- add `local.js` to serve static files using Node's built-in `http` module
- document how to run the new server
- expose `npm run local` script in `package.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68474f7587ac832a98db8e9637df4967