### PR TITLE
Add simple homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ npm start
 ```
 
 The application will be available at [http://localhost:5000](http://localhost:5000).
+
+Opening this URL in your browser displays a simple page from `static/index.html`.
+
+Alternatively, you can run the server using Node's built-in `http` module:
+
+```bash
+npm run local
+```
+
+This starts `local.js` which serves the files in the `static` directory.

--- a/__tests__/local.test.js
+++ b/__tests__/local.test.js
@@ -1,0 +1,43 @@
+const http = require('http');
+const fs = require('fs');
+const { startServer } = require('../local');
+
+describe('local server', () => {
+  let server;
+
+  afterEach((done) => {
+    if (server && server.close) {
+      server.close(done);
+    } else {
+      done();
+    }
+  });
+
+  it('reads files using fs.readFile', (done) => {
+    jest.spyOn(fs, 'readFile').mockImplementation((path, cb) => cb(null, Buffer.from('mocked')));
+    server = startServer(0);
+    server.on('listening', () => {
+      const port = server.address().port;
+      http.get({ hostname: 'localhost', port, path: '/' }, (res) => {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => {
+          expect(data).toBe('mocked');
+          expect(fs.readFile).toHaveBeenCalled();
+          fs.readFile.mockRestore();
+          done();
+        });
+      });
+    });
+  });
+
+  it('logs start message', (done) => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    server = startServer(0);
+    server.on('listening', () => {
+      expect(logSpy).toHaveBeenCalled();
+      logSpy.mockRestore();
+      done();
+    });
+  });
+});

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('express server', () => {
+  it('serves index.html at /', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Hello from Node');
+  });
+});

--- a/local.js
+++ b/local.js
@@ -1,0 +1,36 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 5000;
+
+const server = http.createServer((req, res) => {
+  let filePath = req.url === '/' ? '/index.html' : req.url;
+  const fullPath = path.join(__dirname, 'static', filePath);
+
+  fs.readFile(fullPath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+
+    const ext = path.extname(fullPath);
+    const contentType = ext === '.html' ? 'text/html' : 'text/plain';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+});
+
+function startServer(port = PORT) {
+  return server.listen(port, '0.0.0.0', () => {
+    console.log(`Server running at http://localhost:${port}`);
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { server, startServer };

--- a/package.json
+++ b/package.json
@@ -4,9 +4,15 @@
   "description": "Minimal Node.js application serving static HTML",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "local": "node local.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,10 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'static', 'index.html'));
 });
 
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/static/index.html
+++ b/static/index.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>SimpleAgentCodex</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+  </style>
 </head>
 <body>
-  <h1>Welcome to SimpleAgentCodex</h1>
-  <p>This is a placeholder page.</p>
+  <h1>Hello from Node!</h1>
+  <p>This page is served from the static directory of your Node.js server.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `static/index.html` with a basic landing page
- document the homepage in the README
- export servers so they can be tested
- add jest-based tests for both servers using mocks and spies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474f7587ac832a98db8e9637df4967